### PR TITLE
Handle configuration errors in slack & hipchat

### DIFF
--- a/integrations/hipchat.rb
+++ b/integrations/hipchat.rb
@@ -23,6 +23,14 @@ module Rainforest
           auth_token: config.hipchat_token,
         }
         post URL, body: body
+      rescue Http::Exceptions::HttpException => ex
+        case ex.response.code
+        when 400..499
+          msg = ex.response.body["error"]["message"]
+          raise ConfigurationError.new(msg, original_exception: ex)
+        else
+          raise ex
+        end
       end
     end
   end

--- a/integrations/slack.rb
+++ b/integrations/slack.rb
@@ -18,7 +18,12 @@ module Rainforest
                  { text: render_text(event) }
                end
 
-        post url, body: body.to_json
+        response = post url, body: body.to_json
+        # Slack errors are still `200 OK`. For shame.
+        unless response.parsed_response["ok"]
+          msg = "Connection refused, invalid URL. (#{response.parsed_response["error"]})"
+          raise ConfigurationError.new(msg)
+        end
       end
 
       def message_text(event)

--- a/lib/rainforest/integrations.rb
+++ b/lib/rainforest/integrations.rb
@@ -3,6 +3,7 @@ require "httparty"
 require 'http/exceptions'
 require "active_support/inflector"
 require "rainforest/integrations/version"
+require "rainforest/integrations/exceptions"
 require "rainforest/integrations/base"
 require "rainforest/integrations/event"
 require "rainforest/integrations/config/config"

--- a/lib/rainforest/integrations/exceptions.rb
+++ b/lib/rainforest/integrations/exceptions.rb
@@ -1,0 +1,14 @@
+module Rainforest::Integrations
+
+  class Error < StandardError; end
+
+  class ConfigurationError < Error
+    attr_reader :original_exception
+
+    def initialize(msg, original_exception: nil)
+      @original_exception = original_exception
+      super(msg)
+    end
+  end
+end
+

--- a/spec/integrations/hipchat_spec.rb
+++ b/spec/integrations/hipchat_spec.rb
@@ -19,6 +19,20 @@ module Rainforest
         stub_request(:post, described_class::URL)
         subject.on_event sample_job_failure_event
       end
+
+      context "with an error response" do
+        let(:response_body) { '{"error":{"code":401,"type":"Unauthorized","message":"Auth token invalid. Please see: https:\/\/www.hipchat.com\/docs\/api\/auth"}}' }
+
+        it "raises a ConfigurationError" do
+          stub_request(:post, described_class::URL).
+            to_return(body: response_body, status: 401)
+
+          expect {
+            subject.on_event sample_job_failure_event
+          }.to raise_error(Rainforest::Integrations::ConfigurationError)
+        end
+
+      end
     end
   end
 end


### PR DESCRIPTION
raises a `Rainforest::Integrations::ConfigurationError` that we can capture in the app to inform users of a misconfiguration.

/cc @rainforestapp/devs 
