### PR TITLE
Handle empty configuration parameters in integrations

### DIFF
--- a/integrations/hipchat.rb
+++ b/integrations/hipchat.rb
@@ -12,6 +12,8 @@ module Rainforest
       end
 
       def on_event(event)
+        return if config.hipchat_room.empty? || config.hipchat_token.empty?
+
         message = render_html(event)
         body = {
           room_id: config.hipchat_room,
@@ -35,4 +37,3 @@ module Rainforest
     end
   end
 end
-

--- a/integrations/pivotal.rb
+++ b/integrations/pivotal.rb
@@ -13,6 +13,8 @@ module Rainforest
       receive_events "test_failure"
 
       def on_event(event)
+        return if config.pivotal_api_token.empty? || config.pivotal_project_id.empty?
+
         body = {
           name: render_text(event),
           description: description(event),
@@ -52,5 +54,3 @@ module Rainforest
     end
   end
 end
-
-

--- a/integrations/slack.rb
+++ b/integrations/slack.rb
@@ -11,6 +11,8 @@ module Rainforest
       end
 
       def on_event(event)
+        return if url.empty?
+
         body = if event.name == "of_test_failure"
                  { text: message_text(event),
                    attachments: attachments(event) }
@@ -103,4 +105,3 @@ module Rainforest
     end
   end
 end
-

--- a/spec/integrations/hipchat_spec.rb
+++ b/spec/integrations/hipchat_spec.rb
@@ -33,6 +33,32 @@ module Rainforest
         end
 
       end
+
+      context 'when the room is blank' do
+        let(:config) do
+          {
+            hipchat_room: '',
+            hipchat_token: 'My Token'
+          }
+        end
+
+        it 'does nothing' do
+          expect { subject.on_event sample_event }.to_not raise_error
+        end
+      end
+
+      context 'when the API token is blank' do
+        let(:config) do
+          {
+            hipchat_room: 'My Room',
+            hipchat_token: ''
+          }
+        end
+
+        it 'does nothing' do
+          expect { subject.on_event sample_event }.to_not raise_error
+        end
+      end
     end
   end
 end

--- a/spec/integrations/pivotal_spec.rb
+++ b/spec/integrations/pivotal_spec.rb
@@ -14,7 +14,32 @@ module Rainforest
         stub_request(:post, subject.url)
         subject.on_event sample_job_failure_event
       end
+
+      context 'when the API token is blank' do
+        let(:config) do
+          {
+            pivotal_api_token: '',
+            pivotal_project_id: '123456'
+          }
+        end
+
+        it 'does nothing' do
+          expect { subject.on_event sample_event }.to_not raise_error
+        end
+      end
+
+      context 'when the project id is blank' do
+        let(:config) do
+          {
+            pivotal_api_token: 'My Token',
+            pivotal_project_id: ''
+          }
+        end
+
+        it 'does nothing' do
+          expect { subject.on_event sample_event }.to_not raise_error
+        end
+      end
     end
   end
 end
-

--- a/spec/integrations/slack_spec.rb
+++ b/spec/integrations/slack_spec.rb
@@ -92,5 +92,12 @@ describe Rainforest::Integrations::Slack do
 
   end
 
-end
+  context "with a blank URI" do
+    let(:config) { { slack_url: '' } }
 
+    it 'does nothing' do
+      expect { subject.on_event event }.to_not raise_error
+    end
+  end
+
+end


### PR DESCRIPTION
When users unset integrations in the main app, the setting strings
currently become blank instead of the configuration becoming disabled,
and since all configuration is handled by the integrations gem it's hard
to distinguish between un-setting and changing an integration
setting. This makes the integration gem robust to empty settings,
although it's maybe not the cleanest solution.

@rainforestapp/devs