### PR TITLE
Add a message for missing errors

### DIFF
--- a/lib/integrations/formatter.rb
+++ b/lib/integrations/formatter.rb
@@ -23,6 +23,10 @@ module Integrations
     end
 
     def run_error_message
+      if run[:error_reason].nil? || run[:error_reason].empty?
+        run[:error_reason] = "unspecified reason (please contact help@rainforestqa.com if you'd like help debugging this)"
+      end
+
       "errored: #{run[:error_reason]}."
     end
 

--- a/spec/lib/integrations/base_spec.rb
+++ b/spec/lib/integrations/base_spec.rb
@@ -9,4 +9,12 @@ describe Integrations::Base do
       end.to raise_error
     end
   end
+
+  describe '#send_event' do
+    it 'should be overwritten by child classes' do
+      expect do
+        Integrations::Base.new('foo', {}, {}).send_event
+      end.to raise_error
+    end
+  end
 end

--- a/spec/lib/integrations/formatter_spec.rb
+++ b/spec/lib/integrations/formatter_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+require 'integrations/formatter'
+
+describe Integrations::Formatter do
+  let(:class_instance) do
+    klass = Class.new do
+      include Integrations::Formatter
+      attr_reader :run
+    end
+    klass.new
+  end
+
+  describe '#run_error_message' do
+    context 'with a missing error reason' do
+      context 'nil reason' do
+        before do
+          class_instance.instance_variable_set(:@run, { error_reason: nil })
+        end
+
+        it 'uses "unknown reason"' do
+          expect(class_instance.run_error_message).to eq "errored: unspecified reason (please contact help@rainforestqa.com if you'd like help debugging this)."
+        end
+      end
+
+      context 'empty string for a reason' do
+        before do
+          class_instance.instance_variable_set(:@run, { error_reason: "" })
+        end
+
+        it 'uses "unknown reason"' do
+          expect(class_instance.run_error_message).to eq "errored: unspecified reason (please contact help@rainforestqa.com if you'd like help debugging this)."
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/rainforestapp/Rainforest/issues/6174

Turns out that provisionally_complete can't lead to error, but just in case, let's add a more helpful message if no error is specified.