### PR TITLE
Fix string interpolation in run description

### DIFF
--- a/lib/rainforest/integrations/html_renderer.rb
+++ b/lib/rainforest/integrations/html_renderer.rb
@@ -46,7 +46,7 @@ module Rainforest::Integrations
 
     def run_description(run)
       unless run["description"].nil? or run["description"].empty?
-        %{ (run["description"])}
+        %{ (#{run["description"]})}
       end
     end
   end


### PR DESCRIPTION
Fixes this issue:
![](https://uploads.intercomcdn.com/i/o/2307797/a761dcfa8aa88739fef9f235/Screen%2520Shot%25202015-10-01%2520at%25208.57.00%2520AM.png)

Fixes #36 
@rainforestapp/customer-product please review