### PR TITLE
handle no active webhook errors from slack

### DIFF
--- a/integrations/slack.rb
+++ b/integrations/slack.rb
@@ -31,6 +31,12 @@ module Rainforest
       rescue Addressable::URI::InvalidURIError => ex
         msg = "Invalid URL. It should look like https://you.slack.com/services/hooks/incoming-webhook?token=xyz"
         raise ConfigurationError.new(msg, original_exception: ex)
+      rescue Http::Exceptions::HttpException => e
+        if e.response.code == 404
+          raise ConfigurationError.new("No active webhooks", original_exception: e)
+        else
+          raise e
+        end
       end
 
       def message_text(event)

--- a/spec/integrations/slack_spec.rb
+++ b/spec/integrations/slack_spec.rb
@@ -142,7 +142,6 @@ describe Rainforest::Integrations::Slack do
         subject.on_event event
       }.to raise_error(Rainforest::Integrations::ConfigurationError)
     end
-
   end
 
   context "with a blank URI" do
@@ -153,4 +152,13 @@ describe Rainforest::Integrations::Slack do
     end
   end
 
+  context "with no active hooks" do
+    let(:config) { {slack_url: 'https://hooks.slack.com/disabled_hooks' } }
+
+    it 'should raise a ConfigurationError' do
+      stub_request(:post, config[:slack_url]).to_return(status: 404)
+
+      expect { subject.on_event event }.to raise_error(Rainforest::Integrations::ConfigurationError)
+    end
+  end
 end


### PR DESCRIPTION
Skipping develop because v9000 is on there atm.

Should fix https://github.com/rainforestapp/Rainforest/issues/6410

@shosti 