### PR TITLE
Hotfix: Slack messages for empty durations/descriptions and no-result runs

### DIFF
--- a/lib/integrations/message_formatter.rb
+++ b/lib/integrations/message_formatter.rb
@@ -40,7 +40,8 @@ module Integrations
           "#{n.to_i} #{name}"
         end
       end.compact.reverse.join(', ')
-      time_string.empty? ? 'Not Applicable' : time_string
+      # Fallback in case seconds == 0
+      time_string.empty? ? 'Error/Unknown' : time_string
     end
   end
 end

--- a/lib/integrations/message_formatter.rb
+++ b/lib/integrations/message_formatter.rb
@@ -12,8 +12,7 @@ module Integrations
     end
 
     def run_description
-      description = run[:description]
-      (description && description.length > 0) ? ": #{description}" : ""
+      run[:description].present? ? ": #{run[:description]}" : ""
     end
 
     def run_completion_message

--- a/lib/integrations/message_formatter.rb
+++ b/lib/integrations/message_formatter.rb
@@ -12,7 +12,8 @@ module Integrations
     end
 
     def run_description
-      run[:description] ? ": #{run[:description]}" : ""
+      description = run[:description]
+      (description && description.length > 0) ? ": #{description}" : ""
     end
 
     def run_completion_message
@@ -33,12 +34,13 @@ module Integrations
 
     def humanize_secs(seconds)
       secs = seconds.to_i
-      [[60, :seconds], [60, :minutes], [24, :hours], [1000, :days]].map do |count, name|
+      time_string = [[60, :seconds], [60, :minutes], [24, :hours], [1000, :days]].map do |count, name|
         if secs > 0
           secs, n = secs.divmod(count)
           "#{n.to_i} #{name}"
         end
       end.compact.reverse.join(', ')
+      time_string.empty? ? 'Not Applicable' : time_string
     end
   end
 end

--- a/lib/integrations/slack.rb
+++ b/lib/integrations/slack.rb
@@ -54,7 +54,7 @@ class Integrations::Slack < Integrations::Base
   # it's laid out better in slack's table-format that way
   def run_completion_fields
     [
-      { title: "Result", value: run[:result].capitalize, short: true },
+      { title: "Result", value: run[:result].humanize, short: true },
       {
         title: "Tests Passed: #{run[:total_passed_tests]} - #{test_percentage(run[:total_passed_tests])}%",
         value: "<#{payload[:frontend_url]}?expandedGroups%5B%5D=passed | View all Passed tests>",

--- a/spec/lib/integrations/slack_spec.rb
+++ b/spec/lib/integrations/slack_spec.rb
@@ -4,18 +4,6 @@ require 'integrations'
 describe Integrations::Slack do
   shared_examples_for "Slack notification" do |expected_text|
     it "expects a specific text" do
-        expected_params = {:body => {
-            :attachments => [{
-              :text => expected_text,
-              :fallback => expected_text,
-              :color => 'danger'
-            }]
-          }.to_json,
-          :headers => {
-            'Content-Type' => 'application/json',
-            'Accept' => 'application/json'
-          }
-        }
         response = double('response')
         allow(response).to receive(:code).and_return(200)
 
@@ -33,10 +21,7 @@ describe Integrations::Slack do
     let(:event_type) { 'run_failure' }
     let(:payload) do
       {
-        run: {
-          id: 3,
-          status: 'failed'
-        }
+        run: { id: 3, status: 'failed'}
       }
     end
 
@@ -63,6 +48,7 @@ describe Integrations::Slack do
     end
 
     context "notify of run_completion" do
+      let(:expected_text) { 'Your Rainforest Run (Run#123) has failed.' }
       let(:event_type) { "run_completion" }
       let(:payload) do
         {
@@ -98,6 +84,14 @@ describe Integrations::Slack do
         end
 
         it_should_behave_like "Slack notification", "Your Rainforest Run (<http://example.com | Run #123: some description>) is complete!"
+      end
+
+      context 'when the description is an empty string' do
+        before do
+          payload[:run][:description] = ''
+        end
+
+        it_should_behave_like "Slack notification", "Your Rainforest Run (<http://example.com | Run #123>) is complete!"
       end
     end
 


### PR DESCRIPTION
fixes #52 