### PR TITLE
Hotfix: OAuth validation

### DIFF
--- a/lib/integrations/oauth.rb
+++ b/lib/integrations/oauth.rb
@@ -1,5 +1,5 @@
 module Integrations::Oauth
-  REQUIRED_KEYS = %w(consumer_key consumer_secret signature_method access_token access_secret).freeze
+  REQUIRED_KEYS = %i(consumer_key consumer_secret signature_method access_token access_secret).freeze
 
   def oauth_access_token
     if @oauth_access_token.nil?

--- a/spec/lib/integrations/oauth_spec.rb
+++ b/spec/lib/integrations/oauth_spec.rb
@@ -21,7 +21,7 @@ describe Integrations::Oauth do
     it 'raises Integrations::Error with missing keys' do
       expect {
         subject.oauth_access_token
-      }.to raise_error(Integrations::Error, a_string_including(*required_keys))
+      }.to raise_error(Integrations::Error, a_string_including(*required_keys.map(&:to_s)))
     end
   end
 
@@ -41,7 +41,7 @@ describe Integrations::Oauth do
     it 'raises Integrations::Error with missing keys' do
       expect {
         subject.oauth_access_token
-      }.to raise_error(Integrations::Error, a_string_including(*missing_keys))
+      }.to raise_error(Integrations::Error, a_string_including(*missing_keys.map(&:to_s)))
     end
   end
 


### PR DESCRIPTION
The keys are all symbols, not strings 😵 they are converted here: https://github.com/rainforestapp/rainforest-integrations/blob/develop/app/controllers/events_controller.rb#L16
