### PR TITLE
Add oauth settings from Rainforest

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -15,7 +15,7 @@ class EventsController < ApplicationController
   def create
     begin
       body = MultiJson.load(request.body.read, symbolize_keys: true)
-      unless %i(event_type integrations payload).all? { |key| body.key? key }
+      unless %i(event_type integrations payload oauth_consumer).all? { |key| body.key? key }
         return invalid_request
       end
 

--- a/lib/integrations.rb
+++ b/lib/integrations.rb
@@ -10,7 +10,7 @@ module Integrations
     end
   end
 
-  def self.send_event(event_type:, integrations:, payload:)
+  def self.send_event(event_type:, integrations:, payload:, oauth_consumer:)
     PayloadValidator.new(event_type, integrations, payload).validate!
 
     integrations.each do |integration|
@@ -18,7 +18,7 @@ module Integrations
       raise Error.new('unsupported_integration', "Integration #{integration_name} does not exist") unless Integration.exists?(integration_name)
 
       klass_name = "Integrations::#{integration_name.classify}".constantize
-      integration_object = klass_name.new(event_type, payload, integration[:settings])
+      integration_object = klass_name.new(event_type, payload, integration[:settings], oauth_consumer)
       integration_object.send_event if integration_object.valid?
     end
   end

--- a/lib/integrations/base.rb
+++ b/lib/integrations/base.rb
@@ -2,13 +2,14 @@
 module Integrations
   class Base
     CUSTOMER_SERVICE_EMAIL = 'help@rainforestqa.com'
-    attr_reader :event_type, :payload, :settings, :run
+    attr_reader :event_type, :payload, :settings, :run, :oauth_consumer
 
-    def initialize(event_type, payload, settings)
+    def initialize(event_type, payload, settings, oauth_consumer)
       @event_type = event_type
       @payload = payload
       @run = payload[:run] || {}
       @settings = Integrations::Settings.new(settings)
+      @oauth_consumer = oauth_consumer
     end
 
     # this key should match the key used to identify the integration in integrations.yml

--- a/lib/integrations/oauth.rb
+++ b/lib/integrations/oauth.rb
@@ -1,23 +1,28 @@
 # frozen_string_literal: true
 module Integrations::Oauth
-  REQUIRED_KEYS = %i(consumer_key consumer_secret signature_method access_token access_secret).freeze
+  REQUIRED_KEYS = %i(signature_method access_token access_secret).freeze
 
   def oauth_access_token
-    if @oauth_access_token.nil?
-      validate_oauth_settings!
-
-      oauth_settings = settings[:oauth_settings].with_indifferent_access
-      consumer = OAuth::Consumer.new(
-        oauth_settings[:consumer_key],
-        OpenSSL::PKey::RSA.new(oauth_settings[:consumer_secret]),
-        { signature_method: oauth_settings[:signature_method] }
-      )
-      @oauth_access_token = OAuth::AccessToken.new(consumer, oauth_settings[:access_token], oauth_settings[:access_secret])
-    end
-    @oauth_access_token
+    @oauth_access_token ||= get_oauth_access_token
   end
 
   private
+
+  def get_oauth_access_token
+    validate_oauth_settings!
+
+    oauth_settings = settings[:oauth_settings].with_indifferent_access
+    consumer = OAuth::Consumer.new(
+      oauth_consumer[:key],
+      OpenSSL::PKey::RSA.new(oauth_consumer[:secrets][oauth_settings[:signature_method]]),
+      { signature_method: oauth_settings[:signature_method] }
+    )
+    OAuth::AccessToken.new(
+      consumer,
+      oauth_settings[:access_token],
+      oauth_settings[:access_secret]
+    )
+  end
 
   def validate_oauth_settings!
     missing_values = REQUIRED_KEYS - settings[:oauth_settings].keys

--- a/lib/integrations/pivotal_tracker.rb
+++ b/lib/integrations/pivotal_tracker.rb
@@ -10,8 +10,9 @@ class Integrations::PivotalTracker < Integrations::Base
     'pivotal_tracker'
   end
 
-  def initialize(event_type, payload, settings)
-    super(event_type, payload, settings)
+  # TODO: Don't make the class base URI dynamic - race conditions waiting to happen
+  def initialize(event_type, payload, settings, oauth_consumer)
+    super
     self.class.base_uri "#{PIVOTAL_API_URL}/projects/#{self.settings[:project_id]}"
   end
 

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -19,12 +19,14 @@ describe EventsController, type: :controller do
   end
 
   let(:event_type) { 'run_completion' }
+  let(:oauth_consumer) { {} }
 
   let(:payload) do
     {
       event_type: event_type,
       integrations: integrations,
-      payload: run_payload
+      payload: run_payload,
+      oauth_consumer: oauth_consumer
     }.to_json
   end
 
@@ -53,9 +55,12 @@ describe EventsController, type: :controller do
 
       it 'delegates to Integrations' do
         expect(::Integrations).to receive(:send_event)
-                                   .with(event_type: event_type,
-                                         integrations: integrations,
-                                         payload: run_payload)
+          .with(
+            event_type: event_type,
+            integrations: integrations,
+            payload: run_payload,
+            oauth_consumer: oauth_consumer
+          )
         post :create, payload
       end
 

--- a/spec/lib/integrations/base_spec.rb
+++ b/spec/lib/integrations/base_spec.rb
@@ -5,7 +5,7 @@ describe Integrations::Base do
   describe '#send_event' do
     it 'should be overwritten by child classes' do
       expect do
-        Integrations::Base.new('foo', {}, []).send_event
+        Integrations::Base.new('foo', {}, [], {}).send_event
       end.to raise_error
     end
   end
@@ -16,17 +16,17 @@ describe Integrations::Base do
     end
 
     context 'missing settings' do
-      subject { described_class.new('event', {}, []) }
+      subject { described_class.new('event', {}, [], {}) }
       it { is_expected.to_not be_valid }
     end
 
     context 'empty settings' do
-      subject { described_class.new('event', {}, [{key: 'foo', value: ''}]) }
+      subject { described_class.new('event', {}, [{key: 'foo', value: ''}], {}) }
       it { is_expected.to_not be_valid }
     end
 
     context 'present settings' do
-      subject { described_class.new('event', {}, [{key: 'foo', value: 'val'}]) }
+      subject { described_class.new('event', {}, [{key: 'foo', value: 'val'}], {}) }
       it { is_expected.to be_valid }
     end
   end

--- a/spec/lib/integrations/hip_chat_spec.rb
+++ b/spec/lib/integrations/hip_chat_spec.rb
@@ -5,6 +5,7 @@ require 'integrations'
 describe Integrations::HipChat do
   describe '#send_event' do
     let(:event_type) { 'run_completion' }
+    let(:oauth_consumer) { {} }
     let(:payload) do
       {
         run: {
@@ -50,7 +51,7 @@ describe Integrations::HipChat do
     end
     let(:fake_room) { instance_double('HipChat::Room') }
 
-    subject { described_class.new(event_type, payload, settings) }
+    subject { described_class.new(event_type, payload, settings, oauth_consumer) }
 
     before do
       allow(HipChat::Room).to receive(:new).and_return(fake_room)

--- a/spec/lib/integrations/jira_spec.rb
+++ b/spec/lib/integrations/jira_spec.rb
@@ -2,9 +2,10 @@
 require 'rails_helper'
 
 describe Integrations::Jira do
-  subject { described_class.new(event_type, payload, settings) }
+  subject { described_class.new(event_type, payload, settings, oauth_consumer) }
 
   let(:event_type) { 'run_test_failure' }
+  let(:oauth_consumer) { {} }
   let(:access_token) { double('access_token') }
   let(:base_url) { 'http://example.com' }
   let(:payload) do
@@ -164,7 +165,7 @@ describe Integrations::Jira do
   end
 
   describe '#jira_base_url' do
-    subject { described_class.new(event_type, payload, settings).send(:jira_base_url) }
+    subject { described_class.new(event_type, payload, settings, oauth_consumer).send(:jira_base_url) }
 
     before do
       url_setting = settings.find { |s| s[:key] == 'jira_base_url' }

--- a/spec/lib/integrations/oauth_spec.rb
+++ b/spec/lib/integrations/oauth_spec.rb
@@ -2,10 +2,11 @@
 describe Integrations::Oauth do
   class Klass
     include Integrations::Oauth
-    attr_accessor :settings
+    attr_accessor :settings, :oauth_consumer
 
     def initialize
       @settings = { oauth_settings: {} }
+      @oauth_consumer = { secrets: {} }
     end
   end
 

--- a/spec/lib/integrations/pivotal_tracker_spec.rb
+++ b/spec/lib/integrations/pivotal_tracker_spec.rb
@@ -2,9 +2,10 @@
 require 'rails_helper'
 
 describe Integrations::PivotalTracker do
-  subject { described_class.new(event_type, payload, settings) }
+  subject { described_class.new(event_type, payload, settings, oauth_consumer) }
 
   let(:event_type) { 'run_test_failure' }
+  let(:oauth_consumer) { {} }
   let(:project_id) { '12345' }
   let(:api_token) { 'foobarbaz' }
   let(:base_url) { "#{described_class::PIVOTAL_API_URL}/projects/#{project_id}" }

--- a/spec/lib/integrations/slack_spec.rb
+++ b/spec/lib/integrations/slack_spec.rb
@@ -14,7 +14,7 @@ describe Integrations::Slack do
         expect(text).to eq expected_text
       end.and_return(response)
 
-      described_class.new(event_type, payload, settings).send_event
+      described_class.new(event_type, payload, settings, oauth_consumer).send_event
     end
 
     it 'expects a specific color' do
@@ -27,7 +27,7 @@ describe Integrations::Slack do
         expect(color).to eq expected_color
       end.and_return(response)
 
-      described_class.new(event_type, payload, settings).send_event
+      described_class.new(event_type, payload, settings, oauth_consumer).send_event
     end
 
     it 'expects a specific fallback text without markdown' do
@@ -40,7 +40,7 @@ describe Integrations::Slack do
         expect(fallback).to eq expected_fallback
       end.and_return(response)
 
-      described_class.new(event_type, payload, settings).send_event
+      described_class.new(event_type, payload, settings, oauth_consumer).send_event
     end
   end
 
@@ -53,6 +53,7 @@ describe Integrations::Slack do
         }
       ]
     end
+    let(:oauth_consumer) { {} }
 
     context 'notify of run_completion' do
       let(:expected_text) { 'Your Rainforest Run (Run#123) has failed.' }
@@ -77,7 +78,7 @@ describe Integrations::Slack do
 
       it 'sends a message to Slack' do
         VCR.use_cassette('run_completion_notify_slack') do
-          Integrations::Slack.new(event_type, payload, settings).send_event
+          Integrations::Slack.new(event_type, payload, settings, oauth_consumer).send_event
         end
       end
 
@@ -136,7 +137,7 @@ describe Integrations::Slack do
 
       it 'sends a message to Slack' do
         VCR.use_cassette('run_error_notify_slack') do
-          Integrations::Slack.new(event_type, payload, settings).send_event
+          Integrations::Slack.new(event_type, payload, settings, oauth_consumer).send_event
         end
       end
 
@@ -164,7 +165,7 @@ describe Integrations::Slack do
 
       it 'sends a message to Slack' do
         VCR.use_cassette('webhook_timeout_notify_slack') do
-          Integrations::Slack.new(event_type, payload, settings).send_event
+          Integrations::Slack.new(event_type, payload, settings, oauth_consumer).send_event
         end
       end
 
@@ -199,7 +200,7 @@ describe Integrations::Slack do
 
       it 'sends a message to Slack' do
         VCR.use_cassette('run_test_failure_notify_slack') do
-          Integrations::Slack.new(event_type, payload, settings).send_event
+          Integrations::Slack.new(event_type, payload, settings, oauth_consumer).send_event
         end
       end
 

--- a/spec/lib/integrations_spec.rb
+++ b/spec/lib/integrations_spec.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require 'rails_helper'
+
 describe Integrations do
   describe '.send_event' do
     let(:event_type) { 'run_completion' }
@@ -13,9 +15,15 @@ describe Integrations do
       }
     end
     let(:integrations) { [] }
+    let(:oauth_consumer) { {} }
 
     subject do
-      described_class.send_event(event_type: event_type, integrations: integrations, payload: payload)
+      described_class.send_event(
+        event_type: event_type,
+        integrations: integrations,
+        payload: payload,
+        oauth_consumer: oauth_consumer
+      )
     end
 
     context 'with a nonexistent integration' do
@@ -31,7 +39,9 @@ describe Integrations do
 
       it 'does not call #send_event on the corresponding class for the integration' do
         mock_integration = double
-        expect(Integrations::Slack).to receive(:new).with(event_type, payload, integrations.first[:settings]).and_return mock_integration
+        expect(Integrations::Slack).to receive(:new)
+          .with(event_type, payload, integrations.first[:settings], oauth_consumer)
+          .and_return mock_integration
         expect(mock_integration).to receive(:valid?).and_return(false)
         expect(mock_integration).to_not receive :send_event
         subject
@@ -43,7 +53,9 @@ describe Integrations do
 
       it 'calls #send_event on the corresponding class for the integration' do
         mock_integration = double
-        expect(Integrations::Slack).to receive(:new).with(event_type, payload, integrations.first[:settings]).and_return mock_integration
+        expect(Integrations::Slack).to receive(:new)
+          .with(event_type, payload, integrations.first[:settings], oauth_consumer)
+          .and_return mock_integration
         expect(mock_integration).to receive(:valid?).and_return(true)
         expect(mock_integration).to receive :send_event
         subject


### PR DESCRIPTION
OAuth consumer key and secret will no longer be configured by the client - it will be sent separately from Rainforest.