### PR TITLE
Use indifferent access hash for consumer secrets

### DIFF
--- a/lib/integrations/oauth.rb
+++ b/lib/integrations/oauth.rb
@@ -12,9 +12,13 @@ module Integrations::Oauth
     validate_oauth_settings!
 
     oauth_settings = settings[:oauth_settings].with_indifferent_access
+    secrets = oauth_consumer[:secrets].with_indifferent_access
+
+    # NOTE: if we need to use a different encryption algorithm in the future, use
+    # the signature method to figure out which to use
     consumer = OAuth::Consumer.new(
       oauth_consumer[:key],
-      OpenSSL::PKey::RSA.new(oauth_consumer[:secrets][oauth_settings[:signature_method]]),
+      OpenSSL::PKey::RSA.new(secrets[oauth_settings[:signature_method]]),
       { signature_method: oauth_settings[:signature_method] }
     )
     OAuth::AccessToken.new(

--- a/spec/lib/integrations/oauth_spec.rb
+++ b/spec/lib/integrations/oauth_spec.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require 'rails_helper'
+
 describe Integrations::Oauth do
   class Klass
     include Integrations::Oauth
@@ -6,7 +8,7 @@ describe Integrations::Oauth do
 
     def initialize
       @settings = { oauth_settings: {} }
-      @oauth_consumer = { secrets: {} }
+      @oauth_consumer = { secrets: { 'RSA-SHA1' => 'consumer secret' } }
     end
   end
 


### PR DESCRIPTION
Because we symbolize all keys, we should use an indifferent hash to access OAuth settings, since many of the keys are irregular symbols (like `:RSA-SHA1`).

fixes #103 