### PR TITLE
Add hipchat cards

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: git://github.com/hipchat/hipchat-rb.git
-  revision: d37c6378d094d355c6876b19ceed01e1ee3d7a02
+  revision: 5d427a9de0736293d966b6dbd5cb20a10478a77a
   specs:
-    hipchat (1.5.2)
+    hipchat (1.5.3)
       httparty
       mimemagic
 
@@ -86,7 +86,7 @@ GEM
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
     hitimes (1.2.2)
-    httparty (0.13.5)
+    httparty (0.13.7)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
     i18n (0.7.0)
@@ -234,5 +234,8 @@ DEPENDENCIES
   web-console (~> 2.0)
   webmock
 
+RUBY VERSION
+   ruby 2.2.3p173
+
 BUNDLED WITH
-   1.10.6
+   1.12.4

--- a/fixtures/vcr_cassettes/hipchat_notification_run_completion.yml
+++ b/fixtures/vcr_cassettes/hipchat_notification_run_completion.yml
@@ -1,0 +1,55 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.hipchat.com/v2/room/Test/notification?auth_token=sjc91Sq15qhcyciVoDo7f7jFrZhj0OizRKl8D6ED
+    body:
+      encoding: UTF-8
+      string: '{"room_id":"Test","from":"Rainforest QA","message":"Rainforest \u003ca
+        href=\"http://www.example.com\"\u003eRun #123\u003c/a\u003e is complete!\nResult:
+        \u003cb\u003epassed\u003c/b\u003e\n","message_format":"html","color":"green","card":{"id":"5b619537-4abf-40bb-b198-70f89bca9f27","style":"application","icon":{"url":"https://www.rainforestqa.com/images/favicon-f246a1f7.png"},"title":"Your
+        Rainforest Run (#123) is complete!","url":"http://www.example.com","attributes":[{"label":"Result","value":{"label":"Passed"}},{"label":"Environment","value":{"label":"QA
+        Environment"}},{"label":"Duration","value":{"label":"25 minutes, 3 seconds"}}]},"notify":true}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Date, ETag, Link, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+        X-Backoff
+      Content-Type:
+      - text/html
+      Date:
+      - Thu, 26 May 2016 10:06:25 GMT
+      Location:
+      - https://api.hipchat.com/v2/room/2776193/history/37c6a4aa-5808-4398-8767-1d2d48c47dbe
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Ratelimit-Limit:
+      - '100'
+      X-Ratelimit-Remaining:
+      - '98'
+      X-Ratelimit-Reset:
+      - '1464257375'
+      X-Xss-Protection:
+      - 1; mode=block
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 26 May 2016 10:06:23 GMT
+recorded_with: VCR 2.9.3

--- a/fixtures/vcr_cassettes/hipchat_notification_run_error.yml
+++ b/fixtures/vcr_cassettes/hipchat_notification_run_error.yml
@@ -1,0 +1,55 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.hipchat.com/v2/room/Test/notification?auth_token=sjc91Sq15qhcyciVoDo7f7jFrZhj0OizRKl8D6ED
+    body:
+      encoding: UTF-8
+      string: '{"room_id":"Test","from":"Rainforest QA","message":"Rainforest \u003ca
+        href=\"http://www.example.com\"\u003eRun #123\u003c/a\u003e has encountered
+        an error!\nPlease contact help@rainforestqa.com for more details.\n","message_format":"html","color":"red","card":{"id":"142cd407-b0b0-40be-9263-5d2930d3df49","style":"application","icon":{"url":"https://www.rainforestqa.com/images/favicon-f246a1f7.png"},"title":"Your
+        Rainforest Run (#123) has encountered an error!","url":"http://www.example.com","attributes":[{"label":"Error
+        Reason","value":{"label":"We were unable to create social account(s)"}}]},"notify":true}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Date, ETag, Link, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+        X-Backoff
+      Content-Type:
+      - text/html
+      Date:
+      - Thu, 26 May 2016 10:08:00 GMT
+      Location:
+      - https://api.hipchat.com/v2/room/2776193/history/a9f2be10-e42e-440c-8dc3-13c63d9e4d4c
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Ratelimit-Limit:
+      - '100'
+      X-Ratelimit-Remaining:
+      - '97'
+      X-Ratelimit-Reset:
+      - '1464257375'
+      X-Xss-Protection:
+      - 1; mode=block
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 26 May 2016 10:07:58 GMT
+recorded_with: VCR 2.9.3

--- a/fixtures/vcr_cassettes/hipchat_notification_run_test_failure.yml
+++ b/fixtures/vcr_cassettes/hipchat_notification_run_test_failure.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.hipchat.com/v2/room/Test/notification?auth_token=sjc91Sq15qhcyciVoDo7f7jFrZhj0OizRKl8D6ED
+    body:
+      encoding: UTF-8
+      string: '{"room_id":"Test","from":"Rainforest QA","message":"Rainforest \u003ca
+        href=\"\"\u003eRun #9382\u003c/a\u003e has a failed test!\nFailed Test: \u003ca
+        href=\"http://www.example.com/foo\"\u003eMy failing test\u003c/a\u003e\n","message_format":"html","color":"red","card":{"id":"d4f9b4c7-b03c-4956-b7d3-09927f46c2c6","style":"application","icon":{"url":"https://www.rainforestqa.com/images/favicon-f246a1f7.png"},"title":"Your
+        Rainforest Run (#9382) has failed a test!","url":"http://www.example.com/foo","attributes":[{"label":"Failed
+        Test","value":{"label":"My failing test (#7)"}},{"label":"Environment","value":{"label":"QA
+        Environment"}},{"label":"Browser","value":{"label":"Chrome 43"}}]},"notify":true}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Date, ETag, Link, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+        X-Backoff
+      Content-Type:
+      - text/html
+      Date:
+      - Thu, 26 May 2016 10:04:34 GMT
+      Location:
+      - https://api.hipchat.com/v2/room/2776193/history/64951189-d070-409c-bdcc-69407d4e95c1
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Ratelimit-Limit:
+      - '100'
+      X-Ratelimit-Remaining:
+      - '100'
+      X-Ratelimit-Reset:
+      - '1464257375'
+      X-Xss-Protection:
+      - 1; mode=block
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 26 May 2016 10:04:32 GMT
+recorded_with: VCR 2.9.3

--- a/fixtures/vcr_cassettes/hipchat_notification_webhook_timeout.yml
+++ b/fixtures/vcr_cassettes/hipchat_notification_webhook_timeout.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.hipchat.com/v2/room/Test/notification?auth_token=sjc91Sq15qhcyciVoDo7f7jFrZhj0OizRKl8D6ED
+    body:
+      encoding: UTF-8
+      string: '{"room_id":"Test","from":"Rainforest QA","message":"Rainforest \u003ca
+        href=\"http://www.example.com\"\u003eRun #7\u003c/a\u003e has timed out!\nPlease
+        contact help@rainforestqa.com if you need help debugging this problem.\n","message_format":"html","card":{"id":"8c9afac8-3908-4613-986c-677be036064e","style":"application","icon":{"url":"https://www.rainforestqa.com/images/favicon-f246a1f7.png"},"title":"Your
+        Rainforest Run (#7) has timed out!","url":"http://www.example.com","attributes":[{"label":"Environment","value":{"label":"Foobar"}}]},"notify":true}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Date, ETag, Link, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+        X-Backoff
+      Content-Type:
+      - text/html
+      Date:
+      - Thu, 26 May 2016 10:09:23 GMT
+      Location:
+      - https://api.hipchat.com/v2/room/2776193/history/8938749f-059f-4345-9b7e-572dce0e87a5
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Ratelimit-Limit:
+      - '100'
+      X-Ratelimit-Remaining:
+      - '96'
+      X-Ratelimit-Reset:
+      - '1464257375'
+      X-Xss-Protection:
+      - 1; mode=block
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 26 May 2016 10:09:21 GMT
+recorded_with: VCR 2.9.3

--- a/lib/integrations/hip_chat.rb
+++ b/lib/integrations/hip_chat.rb
@@ -19,7 +19,13 @@ class Integrations::HipChat < Integrations::Base
 
     # TODO: make notify configurable
     begin
-      room.send('Rainforest QA', message, notify: true, color: color)
+      room.send(
+        'Rainforest QA',
+        message,
+        card: card,
+        notify: true,
+        color: color
+      )
     rescue HipChat::ServiceError => e
       # ServiceError is the parent class for all of HipChat's errors. For
       # greater specificity, please see:
@@ -29,6 +35,16 @@ class Integrations::HipChat < Integrations::Base
   end
 
   private
+
+  def card
+    {
+      id: SecureRandom.uuid,
+      style: 'application',
+      icon: {
+        url: 'https://www.rainforestqa.com/images/favicon-f246a1f7.png'
+      }
+    }.merge(self.send(:"#{event_type}_card"))
+  end
 
   def ok_to_send_event?
     settings[:room_token].present? && settings[:room_id].present?
@@ -53,11 +69,55 @@ Failed Test: <a href="#{failed_test[:frontend_url]}">#{failed_test[:title]}</a>
     HTML
   end
 
+  def run_test_failure_card
+    failed_test = payload[:failed_test]
+
+    {
+      title: "Your Rainforest Run (##{run[:id]}) has failed a test!",
+      url: failed_test[:frontend_url],
+      attributes: [
+        {
+          label: "Failed Test",
+          value: { label: "#{failed_test[:title]} (##{failed_test[:id]})" }
+        },
+        {
+          label: 'Environment',
+          value: { label: run[:environment][:name] }
+        },
+        {
+          label: 'Browser',
+          value: { label: payload[:browser][:description] }
+        }
+      ]
+    }
+  end
+
   def run_completion_message
     <<-HTML
 Rainforest <a href="#{payload[:frontend_url]}">Run ##{run[:id]}</a> is complete!
 Result: <b>#{run[:result]}</b>
     HTML
+  end
+
+  def run_completion_card
+    {
+      title: "Your Rainforest Run (##{run[:id]}) is complete!",
+      url: payload[:frontend_url],
+      attributes: [
+        {
+          label: 'Result',
+          value: { label: run[:result].humanize }
+        },
+        {
+          label: 'Environment',
+          value: { label: run[:environment][:name] }
+        },
+        {
+          label: "Duration",
+          value: { label: humanize_secs(run[:time_taken]) }
+        }
+      ]
+    }
   end
 
   def run_error_message
@@ -67,10 +127,36 @@ Please contact #{CUSTOMER_SERVICE_EMAIL} for more details.
     HTML
   end
 
+  def run_error_card
+    {
+      title: "Your Rainforest Run (##{run[:id]}) has encountered an error!",
+      url: payload[:frontend_url],
+      attributes: [
+        {
+          label: 'Error Reason',
+          value: { label: run[:error_reason] }
+        }
+      ]
+    }
+  end
+
   def webhook_timeout_message
     <<-HTML
-Rainforest <a href="#{payload[:frontend_url]}">Run ##{run[:id]}</a> has has timed out!
+Rainforest <a href="#{payload[:frontend_url]}">Run ##{run[:id]}</a> has timed out!
 Please contact #{CUSTOMER_SERVICE_EMAIL} if you need help debugging this problem.
     HTML
+  end
+
+  def webhook_timeout_card
+    {
+      title: "Your Rainforest Run (##{run[:id]}) has timed out!",
+      url: payload[:frontend_url],
+      attributes: [
+        {
+          label: 'Environment',
+          value: { label: run[:environment][:name] }
+        }
+      ]
+    }
   end
 end

--- a/lib/integrations/slack.rb
+++ b/lib/integrations/slack.rb
@@ -24,7 +24,7 @@ class Integrations::Slack < Integrations::Base
   end
 
   def run_test_failure_message
-    'has a failed a test!'
+    'has a failed test!'
   end
 
   def test_percentage(test_quantity)

--- a/spec/lib/integrations/slack_spec.rb
+++ b/spec/lib/integrations/slack_spec.rb
@@ -206,9 +206,9 @@ describe Integrations::Slack do
 
       describe 'message text' do
         it_should_behave_like 'Slack notification',
-                              'Your Rainforest Run (<http://www.example.com | Run #666>) has a failed a test!',
+                              'Your Rainforest Run (<http://www.example.com | Run #666>) has a failed test!',
                               'danger',
-                              'Your Rainforest Run has a failed a test!'
+                              'Your Rainforest Run has a failed test!'
       end
     end
   end


### PR DESCRIPTION
Fixes https://github.com/rainforestapp/rainforest-integrations/issues/71

I left the existing messages there as fallback since some [older] clients apparently can't render cards.

Also, I couldn't fit all of the same information that the Slack integration has because HipChat tries to squeeze them onto one line:
![Overload](https://www.dropbox.com/s/8lqhuxchj6h9qmw/Screenshot%202016-05-26%2017.17.35.png?dl=1)

So here's what I came up with:
![run_test_failure](https://www.dropbox.com/s/56n8hrotzu6d8pv/Screenshot%202016-05-26%2017.16.53.png?dl=1)
![run_completion](https://www.dropbox.com/s/khepuzdv7o4xlrw/Screenshot%202016-05-26%2017.16.06.png?dl=1)
![run_error](https://www.dropbox.com/s/h7bdlk72iq8x6g5/Screenshot%202016-05-26%2017.15.08.png?dl=1)
![webhook_timeout](https://www.dropbox.com/s/fd9uo5fc8tv6w2y/Screenshot%202016-05-26%2017.14.18.png?dl=1)
