### PR TITLE
Capture and use more request failure information

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby '2.2.3'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.1'
-gem 'puma'
+gem 'puma', '2.16.0'
 gem 'awesome_print'
 gem 'dotenv-rails'
 gem 'multi_json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,8 +119,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    puma (2.11.3)
-      rack (>= 1.1, < 2.0)
+    puma (2.16.0)
     rack (1.6.1)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -222,7 +221,7 @@ DEPENDENCIES
   httparty
   multi_json
   oauth
-  puma
+  puma (= 2.16.0)
   rails (= 4.2.1)
   rf-stylez
   rspec-rails
@@ -238,4 +237,4 @@ RUBY VERSION
    ruby 2.2.3p173
 
 BUNDLED WITH
-   1.12.4
+   1.12.5

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -24,7 +24,7 @@ class EventsController < ApplicationController
     rescue MultiJson::ParseError
       invalid_request('unable to parse request', type: 'parse_error')
     rescue Integrations::Error => e
-      invalid_request(e.message, type: e.type)
+      format_integration_error(e)
     rescue PayloadValidator::InvalidPayloadError => e
       invalid_request e.message, type: 'invalid payload'
     end
@@ -34,6 +34,16 @@ class EventsController < ApplicationController
 
   def invalid_request(message = 'invalid request', type: 'invalid_request')
     render json: { error: message, type: type }, status: 400
+  end
+
+  def format_integration_error(exception)
+    exception_info = {
+      error: exception.message,
+      type: exception.type,
+      failed_response_body: exception.response_body,
+      failed_response_code: exception.response_code,
+    }
+    render json: exception_info, status: 400
   end
 
   def verify_signature

--- a/lib/integrations.rb
+++ b/lib/integrations.rb
@@ -1,11 +1,16 @@
 # frozen_string_literal: true
 module Integrations
   class Error < StandardError
-    attr_reader :type, :message
+    attr_reader :type, :message, :response, :response_body, :response_code
 
-    def initialize(type='unknown_error', message='Unknown Error')
+    def initialize(type='unknown_error', message='Unknown Error', response)
       @type = type
       @message = message
+      if response && response.respond_to?(:body)
+        @response = response
+        @response_body = response.body
+        @response_code = response.code
+      end
       super message
     end
   end
@@ -15,7 +20,9 @@ module Integrations
 
     integrations.each do |integration|
       integration_name = integration[:key]
-      raise Error.new('unsupported_integration', "Integration #{integration_name} does not exist") unless Integration.exists?(integration_name)
+      unless Integration.exists?(integration_name)
+        raise Error.new('unsupported_integration', "Integration #{integration_name} does not exist")
+      end
 
       klass_name = "Integrations::#{integration_name.classify}".constantize
       integration_object = klass_name.new(event_type, payload, integration[:settings], oauth_consumer)

--- a/lib/integrations.rb
+++ b/lib/integrations.rb
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 module Integrations
   class Error < StandardError
-    attr_reader :type, :message, :response, :response_body, :response_code
+    attr_reader :type, :message, :response_body, :response_code
 
     def initialize(type='unknown_error', message='Unknown Error', response)
       @type = type
       @message = message
       if response && response.respond_to?(:body)
-        @response = response
         @response_body = response.body
         @response_code = response.code
       end

--- a/lib/integrations/jira.rb
+++ b/lib/integrations/jira.rb
@@ -75,11 +75,11 @@ class Integrations::Jira < Integrations::Base
     when 401
       raise Integrations::Error.new('user_configuration_error',
                                     "Authentication failed. Wrong username and/or password. \
-                                    Keep in mind that your JIRA username is NOT your email address.")
+                                    Keep in mind that your JIRA username is NOT your email address.", response)
     when 404
-      raise Integrations::Error.new('user_configuration_error', 'This JIRA URL does exist.')
+      raise Integrations::Error.new('user_configuration_error', 'This JIRA URL does exist.', response)
     else
-      raise Integrations::Error.new('misconfigured_integration', 'Invalid request to the JIRA API.')
+      raise Integrations::Error.new('misconfigured_integration', 'Invalid request to the JIRA API.', response)
     end
   end
 

--- a/lib/integrations/pivotal_tracker.rb
+++ b/lib/integrations/pivotal_tracker.rb
@@ -94,11 +94,11 @@ class Integrations::PivotalTracker < Integrations::Base
 
   def validate_response!(response)
     if response.code == 404
-      raise Integrations::Error.new('user_configuration_error', 'The project ID provided was not found.')
+      raise Integrations::Error.new('user_configuration_error', 'The project ID provided was not found.', response)
     elsif response.code == 403
-      raise Integrations::Error.new('user_configuration_error', 'The authorization token is invalid.')
+      raise Integrations::Error.new('user_configuration_error', 'The authorization token is invalid.', response)
     elsif response.code != 200
-      raise Integrations::Error.new('user_configuration_error', 'Invalid request to the Pivotal Tracker API.')
+      raise Integrations::Error.new('user_configuration_error', 'Invalid request to the Pivotal Tracker API.', response)
     end
   end
 

--- a/lib/integrations/slack.rb
+++ b/lib/integrations/slack.rb
@@ -48,11 +48,11 @@ class Integrations::Slack < Integrations::Base
                             )
 
     if response.code == 500 && response.parsed_response == 'no_text'
-      raise Integrations::Error.new('user_configuration_error', 'Invalid request to the Slack API (maybe the JSON structure is wrong?).')
+      raise Integrations::Error.new('user_configuration_error', 'Invalid request to the Slack API (maybe the JSON structure is wrong?).', response)
     elsif response.code == 404 && response.parsed_response == 'Bad token'
-      raise Integrations::Error.new('user_configuration_error', 'The provided Slack URL is invalid.')
+      raise Integrations::Error.new('user_configuration_error', 'The provided Slack URL is invalid.', response)
     elsif response.code != 200
-      raise Integrations::Error.new('misconfigured_integration', 'Invalid request to the Slack API.')
+      raise Integrations::Error.new('misconfigured_integration', 'Invalid request to the Slack API.', response)
     end
   end
 

--- a/spec/lib/integrations/oauth_spec.rb
+++ b/spec/lib/integrations/oauth_spec.rb
@@ -25,7 +25,7 @@ describe Integrations::Oauth do
     it 'raises Integrations::Error with missing keys' do
       expect do
         subject.oauth_access_token
-      end.to raise_error(Integrations::Error, a_string_including(*required_keys.map(&:to_s)))
+      end.to raise_error(Integrations::Error)
     end
   end
 
@@ -45,7 +45,7 @@ describe Integrations::Oauth do
     it 'raises Integrations::Error with missing keys' do
       expect do
         subject.oauth_access_token
-      end.to raise_error(Integrations::Error, a_string_including(*missing_keys.map(&:to_s)))
+      end.to raise_exception(Integrations::Error)
     end
   end
 


### PR DESCRIPTION
Adds more information about the failed requests to the custom exception we raise. 
Mainly so we can return that extra information in the response. 