### PR TITLE
Ruby 2.3 fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 source 'https://rubygems.org'
-ruby '2.2.3'
+ruby ENV['CUSTOM_RUBY_VERSION'] || '2.2.3'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.1'


### PR DESCRIPTION
Running tests on Ruby 2.3 was raising `RuntimeError: can't modify frozen String` when sending POST data payload "I'm{invalid".

This PR fixes that issue, allowing us to run this project on Ruby 2.3.