### PR TITLE
add test for integration-test and tweak payload validation

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -18,7 +18,6 @@ class EventsController < ApplicationController
       unless %i(event_type integrations payload oauth_consumer).all? { |key| body.key? key }
         return invalid_request
       end
-
       Integrations.send_event(body)
       render json: { status: 'ok' }, status: :created
     rescue MultiJson::ParseError

--- a/data/events.yml
+++ b/data/events.yml
@@ -13,9 +13,6 @@ webhook_timeout:
   description: Receive a notification when your webhook times out.
   payload:
     run: [id, description, environment]
-integration_test:
-  title: Integration Test
-  description: Receive a notification to make sure your integration works.
 run_test_failure:
   title: Test Failure
   description: Receive a notification when any of your tests fail.

--- a/data/integrations.yml
+++ b/data/integrations.yml
@@ -6,7 +6,6 @@ slack:
     - run_error
     - webhook_timeout
     - run_test_failure
-    - integration_test
   settings:
     - key: 'url'
       title: 'Slack webhook URL'
@@ -18,7 +17,6 @@ hip_chat:
     - run_error
     - webhook_timeout
     - run_test_failure
-    - integration_test
   settings:
     - key: 'room_id'
       title: 'HipChat Room id'
@@ -31,7 +29,6 @@ pivotal_tracker:
   events:
     - webhook_timeout
     - run_test_failure
-    - integration_test
   settings:
     - key: "project_id"
       title: "Project ID for new stories to be posted"
@@ -44,7 +41,6 @@ jira:
   events:
     - webhook_timeout
     - run_test_failure
-    - integration_test
   settings:
     - key: oauth_settings
       oauth_version: 1

--- a/lib/payload_validator.rb
+++ b/lib/payload_validator.rb
@@ -13,7 +13,7 @@ class PayloadValidator
 
   def validate!
     # integration_test doens't have a payload
-    return true if @event_type.to_s == :integration_test
+    return true if @event_type.to_s == "integration_test"
     event = EVENTS.fetch(@event_type.to_s) do
       raise InvalidPayloadError, "Event #{@event_type} is not supported"
     end

--- a/lib/payload_validator.rb
+++ b/lib/payload_validator.rb
@@ -12,6 +12,8 @@ class PayloadValidator
   end
 
   def validate!
+    # integration_test doens't have a payload
+    return true if @event_type.to_s == :integration_test
     event = EVENTS.fetch(@event_type.to_s) do
       raise InvalidPayloadError, "Event #{@event_type} is not supported"
     end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -91,7 +91,7 @@ describe EventsController, type: :controller do
       end
 
       context 'with an integration test' do
-        let(:payload_integration_test) do
+        let(:payload) do
           {
             event_type: 'test_integration',
             integrations: integrations,

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -90,6 +90,23 @@ describe EventsController, type: :controller do
         end
       end
 
+      context 'with an integration test' do
+        let(:payload_integration_test) do
+          {
+            event_type: 'test_integration',
+            integrations: integrations,
+            payload: {},
+            oauth_consumer: oauth_consumer
+          }.to_json
+        end
+
+        it 'returns a 201' do
+          post :create, payload
+          expect(response.code).to eq '201'
+          expect(json['status']).to eq 'ok'
+        end
+      end
+
       context 'with an unsupported integration' do
         let(:service_response) { double(:service_response, code: 400, body: "errors") }
 

--- a/spec/lib/integrations_spec.rb
+++ b/spec/lib/integrations_spec.rb
@@ -61,5 +61,32 @@ describe Integrations do
         subject
       end
     end
+
+    context 'with an integration_test' do
+      let(:event_type) { 'integration_test' }
+      let(:payload) do
+        {}
+      end
+      let(:integrations) { [{:key=>'slack', :settings=>{:url=>"https://example.com/fake_url"}}] }
+      let(:oauth_consumer) { {} }
+      subject do
+        described_class.send_event(
+          event_type: event_type,
+          integrations: integrations,
+          payload: payload,
+          oauth_consumer: oauth_consumer
+        )
+      end
+
+      it 'calls #send_event on the corresponding class for the integration' do
+        mock_integration = double
+        expect(Integrations::Slack).to receive(:new)
+          .with(event_type, payload, integrations.first[:settings], oauth_consumer)
+          .and_return mock_integration
+        expect(mock_integration).to receive(:valid?).and_return(true)
+        expect(mock_integration).to receive :send_event
+        subject
+      end
+    end
   end
 end


### PR DESCRIPTION
integration test event is not needed in the YML and the payload can exceptionally be empty for integration test