### PR TITLE
Add a comment to slack webhook URL in unit test

### DIFF
--- a/spec/lib/integrations/slack_spec.rb
+++ b/spec/lib/integrations/slack_spec.rb
@@ -52,6 +52,7 @@ describe Integrations::Slack do
       [
         {
           key: 'url',
+          # NOTE: This is an invalid slack webhook URL.
           value: 'https://hooks.slack.com/services/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'
         }
       ]


### PR DESCRIPTION
Add a note to clarify that the slack webhook used in unit testing is no longer valid.